### PR TITLE
Use micromath crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ repository = "https://github.com/japaric/madgwick"
 version = "0.1.1"
 
 [dependencies]
-m = "0.1.1"
 mat = "0.2.0"
+micromath = "0.3"


### PR DESCRIPTION
Switches from `m` to [`micromath`] for mathematical operations, and uses the latter's `F32x3` vector type as well as its `Quaternion` type (which was vendored from this crate).

I'm using `micromath` in the [`accelerometer`] crate, so ideally this would provide an interoperable way to support multiple accelerometer backends.

[`micromath`]: https://github.com/NeoBirth/micromath
[`accelerometer`]: https://github.com/NeoBirth/accelerometer.rs